### PR TITLE
Add delete feature for routes and users

### DIFF
--- a/src/frontend/style.css
+++ b/src/frontend/style.css
@@ -297,4 +297,17 @@ input[type="checkbox"] {
     right: 20px;
 }
 
+.delete-btn {
+    background: none;
+    border: none;
+    color: #d32f2f;
+    cursor: pointer;
+    font-size: 16px;
+    margin-left: 10px;
+}
+
+.delete-btn:hover {
+    color: #c62828;
+}
+
 


### PR DESCRIPTION
## Summary
- allow deleting rutas and usuarios from Firestore
- show delete buttons in the UI
- style new delete buttons

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68598fa6de408328aae32df09df60c8c