### PR TITLE
Add multiple route upload

### DIFF
--- a/src/frontend/html/gestionar-rutas.html
+++ b/src/frontend/html/gestionar-rutas.html
@@ -23,7 +23,7 @@
             <div class="rutas-header">
                 <h2>Rutas</h2>
                 <label for="fileInput" class="btn registrar-ruta-btn">Registrar Ruta</label>
-                <input type="file" id="fileInput" class="hidden-input">
+                <input type="file" id="fileInput" class="hidden-input" multiple>
             </div>
             <ul id="rutasList" class="list large-list">
                 <li class="list-item-clickable ruta-item">


### PR DESCRIPTION
## Summary
- allow multiple file uploads
- upload all selected routes sequentially

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685f25509e5c832885858084fdd56537