### PR TITLE
Usar icono de gota en mapa

### DIFF
--- a/src/frontend/app/app.js
+++ b/src/frontend/app/app.js
@@ -256,7 +256,8 @@ export async function loadRutasPorLocalidad(cliente, localidad) {
                 actions.appendChild(progressLink);
 
                 const mapaBtn = document.createElement("button");
-                mapaBtn.textContent = "🗺️";
+                mapaBtn.innerHTML =
+                    '<svg viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z"></path></svg>';
                 mapaBtn.classList.add("map-btn");
                 mapaBtn.disabled = completado === 0;
                 mapaBtn.addEventListener("click", (e) => {

--- a/src/frontend/style.css
+++ b/src/frontend/style.css
@@ -524,6 +524,12 @@ input[type="checkbox"] {
     font-size:16px;
     margin-left:10px;
 }
+.map-btn svg{
+    width:1em;
+    height:1em;
+    fill:currentColor;
+    vertical-align:middle;
+}
 .map-btn::before{
     content:"|";
     color:#999;


### PR DESCRIPTION
## Summary
- incorporar un ícono tipo gota en el botón de mapa
- adaptar estilos para que herede el color del botón

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862c3743c6883288a6c9a8e7725b795