### PR TITLE
Fix ordering of route path

### DIFF
--- a/src/frontend/app/mapa.js
+++ b/src/frontend/app/mapa.js
@@ -1,5 +1,5 @@
 import { db } from './config.js'
-import { doc, collection, getDocs } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js'
+import { doc, collection, getDocs, query, orderBy } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js'
 const parametros = new URLSearchParams(window.location.search)
 const ruta = parametros.get('ruta')
 const mapa = L.map('mapa').setView([0,0],13)
@@ -7,7 +7,8 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{}).addTo(mapa)
 async function dibujar(){
     const refRuta = doc(db,'Rutas',ruta)
     const refRecorrido = collection(refRuta,'RutaRecorrido')
-    const snap = await getDocs(refRecorrido)
+    const consulta = query(refRecorrido, orderBy('Orden'))
+    const snap = await getDocs(consulta)
     const puntos = snap.docs.map(d=>[d.data().latitud,d.data().longitud])
     if(puntos.length){
         mapa.setView(puntos[0],13)


### PR DESCRIPTION
## Summary
- sort subcollection records in `mapa.js` by the `Orden` field to display the route in proper order

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6862db5c3e348328b425ef62509ac2f3