### PR TITLE
Filtrar puntos sin coordenadas

### DIFF
--- a/src/frontend/app/mapa.js
+++ b/src/frontend/app/mapa.js
@@ -10,6 +10,7 @@ async function dibujar(){
     const resultado = await getDocs(refRecorrido)
     const puntos = resultado.docs
         .sort((a,b)=>parseInt(a.id)-parseInt(b.id))
+        .filter(d=>d.data().latitud!=='' && d.data().longitud!=='')
         .map(d=>[d.data().latitud,d.data().longitud])
     if(puntos.length){
         mapa.setView(puntos[0],13)


### PR DESCRIPTION
## Summary
- filtrar documentos con latitud o longitud en blanco antes de dibujar en el mapa

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862f88506748328b479839c282450bb