### PR TITLE
Mostrar info adicional en mapa

### DIFF
--- a/src/frontend/app/mapa.js
+++ b/src/frontend/app/mapa.js
@@ -14,7 +14,8 @@ async function dibujar(){
     const puntos = datos.map(d=>({
         latitud:d.data().latitud,
         longitud:d.data().longitud,
-        fecha:d.data().fecha_hora_lectura
+        fecha:d.data().fecha_hora_lectura,
+        medidor:d.data().medidor
     }))
     if(puntos.length){
         mapa.setView([puntos[0].latitud,puntos[0].longitud],13)
@@ -22,7 +23,7 @@ async function dibujar(){
         L.polyline(coords,{color:'green',dashArray:'4 6'}).addTo(mapa)
         puntos.forEach(p=>{
             L.circleMarker([p.latitud,p.longitud],{radius:4,color:'red',fillColor:'red',fillOpacity:0.8})
-                .bindTooltip(p.fecha)
+                .bindTooltip(`${p.fecha}<br>Medidor: ${p.medidor}`)
                 .addTo(mapa)
         })
     }


### PR DESCRIPTION
## Summary
- mostrar el número de medidor junto con la fecha de lectura al pasar el cursor sobre cada punto del mapa

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68643877f8308328b88c66cd5719fb19