### PR TITLE
Fix popup overlay inputs

### DIFF
--- a/src/frontend/style.css
+++ b/src/frontend/style.css
@@ -255,6 +255,8 @@ body[data-page='localidades'] h1 {
     border: 1px solid #ccc;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+    box-sizing: border-box;
     outline: none;
     transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
@@ -491,6 +493,8 @@ input[type="checkbox"] {
     flex-direction: column;
     align-items: center;
     gap: 15px;
+    width: 100%;
+    max-width: 500px;
 }
 
 .popup-logo {


### PR DESCRIPTION
## Summary
- keep popup inputs contained by widening the popup box and adding border-box sizing

## Testing
- `grep -n "box-sizing" src/frontend/style.css`
- `grep -n "max-width: 500px" src/frontend/style.css`
- `grep -n "background-color" src/frontend/style.css | head`


------
https://chatgpt.com/codex/tasks/task_e_6864410101dc8328afcab3a5f56a6ee9