### PR TITLE
Calcular avance de rutas desde mediciones actuales

### DIFF
--- a/src/frontend/app/app.js
+++ b/src/frontend/app/app.js
@@ -219,9 +219,11 @@ export async function loadRutasPorLocalidad(cliente, localidad) {
 
             if (rutaDoc.exists()) {
                 const rutaId = rutaDoc.id;
-                const rutaData = rutaDoc.data();
-
-                const completado = rutaData.completado || 0;
+                const refLecturas = collection(rutaRef,'RutaRecorrido');
+                const lecturas = await getDocs(refLecturas);
+                const total = lecturas.size;
+                const conMedicion = lecturas.docs.filter(d=>d.data().medicion_actual).length;
+                const completado = total ? conMedicion/total*100 : 0;
                 const bucketUrl = `https://storage.googleapis.com/testados-rutas-exportadas/testados-rutas-exportadas/${cliente}/${localidad}/${rutaId}.csv`;
 
                 const asignada = await rutaTieneAsignados(rutaRef);


### PR DESCRIPTION
## Resumen
- Derivado del porcentaje completado según mediciones actuales en cada ruta.
- Uso del porcentaje calculado para el enlace de progreso y para habilitar el botón de mapa.

## Pruebas
- `npm test` (falla: no se encontró package.json)


------
https://chatgpt.com/codex/tasks/task_e_688f715e523c8328ada13b26bd16f374